### PR TITLE
Task8 delete comment endpoint

### DIFF
--- a/__tests__/comments.test.js
+++ b/__tests__/comments.test.js
@@ -231,7 +231,34 @@ describe('POST: /api/articles/:article_id/comments', () => {
 });
 
 describe('DELETE: /api/comments/:comment_id', () => {
-  it.todo('204: comment is deleted when provided a comment_id that exists');
-  it.todo('404: not found returned when the comment_id does not exist');
-  it.todo('400: bad request returned if comment_id is not an int');
+  it('204: comment is deleted when provided a comment_id that exists', async () => {
+    const { status, body } = await request(app).delete('/api/comments/3');
+    expect(status).toBe(204);
+    expect(body).toBeEmpty();
+
+    const {
+      body: { comments },
+    } = await request(app).get('/api/articles/1/comments');
+    expect(comments.length).toBe(10);
+  });
+
+  it('404: not found returned when the comment_id does not exist', async () => {
+    async () => {
+      const {
+        status,
+        body: { msg },
+      } = await request(app).delete('/api/comments/99');
+      expect(status).toBe(404);
+      expect(msg).toEqual('Not Found');
+    };
+  });
+
+  it('400: bad request returned if comment_id is not an int', async () => {
+    const {
+      status,
+      body: { msg },
+    } = await request(app).delete('/api/comments/foo');
+    expect(status).toBe(400);
+    expect(msg).toEqual('Bad Request');
+  });
 });

--- a/__tests__/comments.test.js
+++ b/__tests__/comments.test.js
@@ -229,3 +229,9 @@ describe('POST: /api/articles/:article_id/comments', () => {
     expect(msg).toEqual('Bad Request: invalid request body');
   });
 });
+
+describe('DELETE: /api/comments/:comment_id', () => {
+  it.todo('204: comment is deleted when provided a comment_id that exists');
+  it.todo('404: not found returned when the comment_id does not exist');
+  it.todo('400: bad request returned if comment_id is not an int');
+});

--- a/app/app.js
+++ b/app/app.js
@@ -14,6 +14,7 @@ const {
 const {
   getCommentsByArticleId,
   postCommentbyArticleId,
+  deleteComment,
 } = require('../controllers/comments.controller');
 const app = express();
 
@@ -34,6 +35,8 @@ app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 app.post('/api/articles/:article_id/comments', postCommentbyArticleId);
 
 app.patch('/api/articles/:article_id', patchArticle);
+
+app.delete('/api/comments/:comment_id', deleteComment);
 
 app.all('/*', (_, response) => {
   response.status(404).send({ msg: 'route not found' });

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,6 +1,7 @@
 const {
   fetchCommentsByArticleId,
   createNewComment,
+  removeComment,
 } = require('../models/comments.model');
 
 exports.getCommentsByArticleId = async (request, response, next) => {
@@ -20,7 +21,17 @@ exports.postCommentbyArticleId = async (request, response, next) => {
       body,
     } = request;
     const newComment = await createNewComment(article_id, body);
-    response.status(201).send({ comment: newComment});
+    response.status(201).send({ comment: newComment });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.deleteComment = async (request, response, next) => {
+  try {
+    const { comment_id } = request.params;
+    await removeComment(comment_id);
+    response.status(204).send();
   } catch (error) {
     next(error);
   }

--- a/endpoints.json
+++ b/endpoints.json
@@ -94,5 +94,10 @@
         }
       ]
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes a comment",
+    "queries": [],
+    "exampleResponse": {}
   }
 }

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -34,3 +34,7 @@ exports.createNewComment = async (article_id, reqBody) => {
 
   return rows;
 };
+
+exports.removeComment = async (comment_id) => {
+  await db.query(`DELETE FROM comments WHERE comment_id = $1`, [comment_id]);
+};


### PR DESCRIPTION
TASK 8

tests and logic for a new endpoint /api/comments/:comment_id to handle deleting a single comment